### PR TITLE
Fix issue during Pulling the system 

### DIFF
--- a/wiki/UART-ADB-Root.md
+++ b/wiki/UART-ADB-Root.md
@@ -96,7 +96,7 @@ https://github.com/tintinweb/pub/tree/master/pocs/cve-2017-13208
 
  ## Currently only works on Linux or Windows Subsystem for Linux 2 with adb installed.
 
-Use a Paperclip to press it in the RESET hole right from the USB Connector. While doing this press the on/off button to boot in Android Recovery. Use `adb pull /dev/block/mmcblk0p12 /patch/to/file`. And mount over `sudo mount -t ext4 /patch/to/file/mmcblk0p12 /mount/patch/` `nano /mount/patch/build.prop` and add
+Use a Paperclip to press it in the RESET hole right from the USB Connector. While doing this press the on/off button to boot in Android Recovery. Use `adb root` and `adb pull /dev/block/mmcblk0p12 /patch/to/file`. And mount over `sudo mount -t ext4 /patch/to/file/mmcblk0p12 /mount/patch/` `nano /mount/patch/build.prop` and add
 ```
 persist.service.adb.enable=1
 persist.service.debuggable=1  


### PR DESCRIPTION
@chrisUse issued in issue #5 that the pull isn't working. Is fixed with this PR.

Citation from @chtisUse

> Hey i have the same issue with hardware version BTS84_V5_20200622. I tested at first with the "recovery without opening" without any luck. Now i open the box and pin on the UART but @Dotsch2005 i don't get access. My test system is linux and i use gtkterm for serial communication. @SciLor i think you are right in newer versions they disable it. The only one reaction for keyboard import that i get is "GPIO0_INTEN: 0x00001920
01c-armoff-2345sram786Kd543210
GPIO0_INTEN: 0x00001920
01c-armoff-2345sram786". Is there any chance to get access?
The error was the following

`
adb pull /dev/block/mmcblk0p12 image.row
adb: error: failed to copy '/dev/block/mmcblk0p12' to 'image.row': remote Permission denied
`
With `adb root` it was fixed. Included in this manual with this PR.
